### PR TITLE
Fix deployment notebook to include preprocessor

### DIFF
--- a/notebooks/06_deployment_submission.ipynb
+++ b/notebooks/06_deployment_submission.ipynb
@@ -1,184 +1,151 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "999d05f0",
-   "metadata": {},
-   "source": [
-    "# Deployment & Submission: Titanic Machine Learning from Disaster\n",
-    "\n",
-    "## Overview\n",
-    "\n",
-    "This notebook documents the **Deployment** phase (CRISP-DM Phase 6) for the Titanic Kaggle competition. It covers the process of generating, validating, and submitting predictions, archiving artifacts, and logging results for reproducibility and business reporting.\n",
-    "\n",
-    "---\n",
-    "**CRISP-DM Phase 6 of 6** | **Previous:** [Evaluation](05_evaluation.ipynb)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e1e99d60",
-   "metadata": {},
-   "source": [
-    "## 1. Submission Workflow & Checklist\n",
-    "\n",
-    "**Deployment Steps:**\n",
-    "1. Generate predictions for the test set using the final model pipeline.\n",
-    "2. Format the submission file:\n",
-    "   - Exactly 2 columns: `PassengerId`, `Survived`\n",
-    "   - 418 rows (matches `test.csv`)\n",
-    "   - No extra columns or index; `Survived` as integer {0,1}\n",
-    "3. Save submission as `submission/submission_YYYYMMDD_modelname.csv`.\n",
-    "4. Validate file format and completeness.\n",
-    "5. Submit to Kaggle and log leaderboard score.\n",
-    "6. Archive model, pipeline, and notebook for reproducibility.\n",
-    "\n",
-    "**Reference:** See planning.md for full checklist and code snippets."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "e76c39a6",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/elizabethparnell/anaconda3/lib/python3.12/site-packages/sklearn/utils/validation.py:2742: UserWarning: X has feature names, but GradientBoostingClassifier was fitted without feature names\n",
-      "  warnings.warn(\n"
-     ]
+      "cell_type": "markdown",
+      "id": "999d05f0",
+      "metadata": {},
+      "source": [
+        "# Deployment & Submission: Titanic Machine Learning from Disaster\n",
+        "\n",
+        "## Overview\n",
+        "\n",
+        "This notebook documents the **Deployment** phase (CRISP-DM Phase 6) for the Titanic Kaggle competition. It covers the process of generating, validating, and submitting predictions, archiving artifacts, and logging results for reproducibility and business reporting.\n",
+        "\n",
+        "---\n",
+        "**CRISP-DM Phase 6 of 6** | **Previous:** [Evaluation](05_evaluation.ipynb)"
+      ]
     },
     {
-     "ename": "ValueError",
-     "evalue": "could not convert string to float: 'Kelly, Mr. James'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m/var/folders/pg/cdp78cks40qdtht4kmcd50zc0000gn/T/ipykernel_47815/354336498.py\u001b[0m in \u001b[0;36m?\u001b[0;34m()\u001b[0m\n\u001b[1;32m     18\u001b[0m     \u001b[0mtest\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_csv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtest_path\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m     \u001b[0mpipeline\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mload\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmodel_path\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     20\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     21\u001b[0m     \u001b[0;31m# Predict\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 22\u001b[0;31m     \u001b[0mpreds\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpipeline\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpredict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtest\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     23\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     24\u001b[0m     \u001b[0;31m# Format submission file\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     25\u001b[0m     submission = pd.DataFrame({\n",
-      "\u001b[0;32m~/anaconda3/lib/python3.12/site-packages/sklearn/ensemble/_gb.py\u001b[0m in \u001b[0;36m?\u001b[0;34m(self, X)\u001b[0m\n\u001b[1;32m   1623\u001b[0m         \u001b[0;34m-\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1624\u001b[0m         \u001b[0my\u001b[0m \u001b[0;34m:\u001b[0m \u001b[0mndarray\u001b[0m \u001b[0mof\u001b[0m \u001b[0mshape\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mn_samples\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1625\u001b[0m             \u001b[0mThe\u001b[0m \u001b[0mpredicted\u001b[0m \u001b[0mvalues\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1626\u001b[0m         \"\"\"\n\u001b[0;32m-> 1627\u001b[0;31m         \u001b[0mraw_predictions\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdecision_function\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1628\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mraw_predictions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mndim\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m:\u001b[0m  \u001b[0;31m# decision_function already squeezed it\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1629\u001b[0m             \u001b[0mencoded_classes\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mraw_predictions\u001b[0m \u001b[0;34m>=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mastype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1630\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/lib/python3.12/site-packages/sklearn/ensemble/_gb.py\u001b[0m in \u001b[0;36m?\u001b[0;34m(self, X)\u001b[0m\n\u001b[1;32m   1576\u001b[0m             \u001b[0morder\u001b[0m \u001b[0mof\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mclasses\u001b[0m \u001b[0mcorresponds\u001b[0m \u001b[0mto\u001b[0m \u001b[0mthat\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mattribute\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1577\u001b[0m             \u001b[0;34m:\u001b[0m\u001b[0mterm\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m`\u001b[0m\u001b[0mclasses_\u001b[0m\u001b[0;34m`\u001b[0m\u001b[0;34m.\u001b[0m \u001b[0mRegression\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mbinary\u001b[0m \u001b[0mclassification\u001b[0m \u001b[0mproduce\u001b[0m \u001b[0man\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1578\u001b[0m             \u001b[0marray\u001b[0m \u001b[0mof\u001b[0m \u001b[0mshape\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mn_samples\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1579\u001b[0m         \"\"\"\n\u001b[0;32m-> 1580\u001b[0;31m         X = validate_data(\n\u001b[0m\u001b[1;32m   1581\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mX\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mDTYPE\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0morder\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"C\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0maccept_sparse\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"csr\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreset\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1582\u001b[0m         \u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1583\u001b[0m         \u001b[0mraw_predictions\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_raw_predict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/lib/python3.12/site-packages/sklearn/utils/validation.py\u001b[0m in \u001b[0;36m?\u001b[0;34m(_estimator, X, y, reset, validate_separately, skip_check_array, **check_params)\u001b[0m\n\u001b[1;32m   2950\u001b[0m             \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2951\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2952\u001b[0m             \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mX\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0my\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2953\u001b[0m     \u001b[0;32melif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mno_val_X\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mno_val_y\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2954\u001b[0;31m         \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcheck_array\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mX\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minput_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"X\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcheck_params\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2955\u001b[0m     \u001b[0;32melif\u001b[0m \u001b[0mno_val_X\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mno_val_y\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2956\u001b[0m         \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_check_y\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0my\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mcheck_params\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2957\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/lib/python3.12/site-packages/sklearn/utils/validation.py\u001b[0m in \u001b[0;36m?\u001b[0;34m(array, accept_sparse, accept_large_sparse, dtype, order, copy, force_writeable, force_all_finite, ensure_all_finite, ensure_non_negative, ensure_2d, allow_nd, ensure_min_samples, ensure_min_features, estimator, input_name)\u001b[0m\n\u001b[1;32m   1050\u001b[0m                         \u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1051\u001b[0m                     \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mxp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mastype\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdtype\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1052\u001b[0m                 \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1053\u001b[0m                     \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_asarray_with_order\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0morder\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0morder\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdtype\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mxp\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mxp\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1054\u001b[0;31m             \u001b[0;32mexcept\u001b[0m \u001b[0mComplexWarning\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mcomplex_warning\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1055\u001b[0m                 raise ValueError(\n\u001b[1;32m   1056\u001b[0m                     \u001b[0;34m\"Complex data not supported\\n{}\\n\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1057\u001b[0m                 \u001b[0;34m)\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mcomplex_warning\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/lib/python3.12/site-packages/sklearn/utils/_array_api.py\u001b[0m in \u001b[0;36m?\u001b[0;34m(array, dtype, order, copy, xp, device)\u001b[0m\n\u001b[1;32m    753\u001b[0m         \u001b[0;31m# Use NumPy API to support order\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    754\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mcopy\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    755\u001b[0m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnumpy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0morder\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0morder\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdtype\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    756\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 757\u001b[0;31m             \u001b[0marray\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnumpy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0masarray\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marray\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0morder\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0morder\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdtype\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    758\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    759\u001b[0m         \u001b[0;31m# At this point array is a NumPy ndarray. We convert it to an array\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    760\u001b[0m         \u001b[0;31m# container that is consistent with the input's namespace.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/lib/python3.12/site-packages/pandas/core/generic.py\u001b[0m in \u001b[0;36m?\u001b[0;34m(self, dtype, copy)\u001b[0m\n\u001b[1;32m   2149\u001b[0m     def __array__(\n\u001b[1;32m   2150\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdtype\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mnpt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mDTypeLike\u001b[0m \u001b[0;34m|\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbool_t\u001b[0m \u001b[0;34m|\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2151\u001b[0m     \u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mndarray\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2152\u001b[0m         \u001b[0mvalues\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_values\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2153\u001b[0;31m         \u001b[0marr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0masarray\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdtype\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdtype\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2154\u001b[0m         if (\n\u001b[1;32m   2155\u001b[0m             \u001b[0mastype_is_view\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdtype\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0marr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdtype\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2156\u001b[0m             \u001b[0;32mand\u001b[0m \u001b[0musing_copy_on_write\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: could not convert string to float: 'Kelly, Mr. James'"
-     ]
-    }
-   ],
-   "source": [
-    "# Generate predictions for test set using final model pipeline\n",
-    "import pandas as pd\n",
-    "from joblib import load\n",
-    "from datetime import datetime\n",
-    "import os\n",
-    "\n",
-    "# Paths\n",
-    "test_path = '../data/raw/test.csv'\n",
-    "model_path = '../models/final_model.pkl'\n",
-    "\n",
-    "# Check for required files\n",
-    "if not os.path.exists(test_path):\n",
-    "    print(f'ERROR: Test data not found at {test_path}. Please add test.csv to this location.')\n",
-    "elif not os.path.exists(model_path):\n",
-    "    print(f'ERROR: Model pipeline not found at {model_path}. Please train and save your model pipeline.')\n",
-    "else:\n",
-    "    # Load test data and model pipeline\n",
-    "    test = pd.read_csv(test_path)\n",
-    "    pipeline = load(model_path)\n",
-    "\n",
-    "    # Predict\n",
-    "    preds = pipeline.predict(test)\n",
-    "\n",
-    "    # Format submission file\n",
-    "    submission = pd.DataFrame({\n",
-    "        'PassengerId': test['PassengerId'],\n",
-    "        'Survived': preds.astype(int)\n",
-    "    })\n",
-    "\n",
-    "    # Save with timestamp and model name\n",
-    "    today = datetime.today().strftime('%Y%m%d')\n",
-    "    model_name = 'gbdt'  # Update if needed\n",
-    "    submission_path = f'submission/submission_{today}_{model_name}.csv'\n",
-    "    submission.to_csv(submission_path, index=False)\n",
-    "\n",
-    "    print(f'Submission file saved to {submission_path}')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "e541f451",
-   "metadata": {},
-   "outputs": [
+      "cell_type": "markdown",
+      "id": "e1e99d60",
+      "metadata": {},
+      "source": [
+        "## 1. Submission Workflow & Checklist\n",
+        "\n",
+        "**Deployment Steps:**\n",
+        "1. Generate predictions for the test set using the saved preprocessor and final model.\n",
+        "2. Format the submission file:\n",
+        "   - Exactly 2 columns: `PassengerId`, `Survived`\n",
+        "   - 418 rows (matches `test.csv`)\n",
+        "   - No extra columns or index; `Survived` as integer {0,1}\n",
+        "3. Save submission as `submission/submission_YYYYMMDD_modelname.csv`.\n",
+        "4. Validate file format and completeness.\n",
+        "5. Submit to Kaggle and log leaderboard score.\n",
+        "6. Archive model, preprocessor, and notebook for reproducibility.\n",
+        "\n",
+        "**Reference:** See planning.md for full checklist and code snippets.\n"
+      ]
+    },
     {
-     "ename": "NameError",
-     "evalue": "name 'submission' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[2], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# Validate submission file format\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m submission\u001b[38;5;241m.\u001b[39mshape \u001b[38;5;241m==\u001b[39m (\u001b[38;5;241m418\u001b[39m, \u001b[38;5;241m2\u001b[39m), \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mSubmission must have 418 rows and 2 columns.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mset\u001b[39m(submission\u001b[38;5;241m.\u001b[39mcolumns) \u001b[38;5;241m==\u001b[39m {\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mPassengerId\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mSurvived\u001b[39m\u001b[38;5;124m'\u001b[39m}, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mColumns must be PassengerId and Survived.\u001b[39m\u001b[38;5;124m'\u001b[39m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m submission[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mSurvived\u001b[39m\u001b[38;5;124m'\u001b[39m]\u001b[38;5;241m.\u001b[39misin([\u001b[38;5;241m0\u001b[39m,\u001b[38;5;241m1\u001b[39m])\u001b[38;5;241m.\u001b[39mall(), \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mSurvived must be 0 or 1.\u001b[39m\u001b[38;5;124m'\u001b[39m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'submission' is not defined"
-     ]
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e76c39a6",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Generate predictions for test set using saved preprocessor and final model\n",
+        "import pandas as pd\n",
+        "from joblib import load\n",
+        "from datetime import datetime\n",
+        "from pathlib import Path\n",
+        "\n",
+        "# Paths\n",
+        "test_path = Path('../data/raw/test.csv')\n",
+        "model_path = Path('../models/final_model.pkl')\n",
+        "preprocessor_path = Path('../data/processed/preprocessor.pkl')\n",
+        "\n",
+        "# Check for required files\n",
+        "if not test_path.exists():\n",
+        "    print(f'ERROR: Test data not found at {test_path}. Please add test.csv to this location.')\n",
+        "elif not model_path.exists():\n",
+        "    print(f'ERROR: Model not found at {model_path}. Please train and save your model.')\n",
+        "elif not preprocessor_path.exists():\n",
+        "    print(f'ERROR: Preprocessor not found at {preprocessor_path}. Please ensure data preparation step was completed.')\n",
+        "else:\n",
+        "    # Load artifacts\n",
+        "    test = pd.read_csv(test_path)\n",
+        "    preprocessor = load(preprocessor_path)\n",
+        "    model = load(model_path)\n",
+        "\n",
+        "    # Transform and predict\n",
+        "    X_test = preprocessor.transform(test)\n",
+        "    preds = model.predict(X_test)\n",
+        "\n",
+        "    # Format submission file\n",
+        "    submission = pd.DataFrame({\n",
+        "        'PassengerId': test['PassengerId'],\n",
+        "        'Survived': preds.astype(int)\n",
+        "    })\n",
+        "\n",
+        "    # Save with timestamp and model name\n",
+        "    today = datetime.today().strftime('%Y%m%d')\n",
+        "    model_name = 'gbdt'  # Update if needed\n",
+        "    submission_path = Path('submission') / f'submission_{today}_{model_name}.csv'\n",
+        "    submission.to_csv(submission_path, index=False)\n",
+        "\n",
+        "    print(f'Submission file saved to {submission_path}')\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e541f451",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Validate submission file format\n",
+        "try:\n",
+        "    submission\n",
+        "except NameError:\n",
+        "    print('ERROR: Submission file not created. Please run the previous cell and ensure required files are present.')\n",
+        "else:\n",
+        "    assert submission.shape == (418, 2), 'Submission must have 418 rows and 2 columns.'\n",
+        "    assert set(submission.columns) == {'PassengerId', 'Survived'}, 'Columns must be PassengerId and Survived.'\n",
+        "    assert submission['Survived'].isin([0,1]).all(), 'Survived must be 0 or 1.'\n",
+        "    print('Submission file format validated.')\n",
+        "\n",
+        "    # Log leaderboard score (manual step after Kaggle submission)\n",
+        "    lb_score = None  # Fill in after submission\n",
+        "    print(f'Kaggle LB score: {lb_score if lb_score else \"<to be filled after submission>\"}')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "b338eb18",
+      "metadata": {},
+      "source": [
+        "## 2. Archiving & Reproducibility\n",
+        "\n",
+        "- Archive the final model, preprocessor, feature columns, and submission file.\n",
+        "- Save the deployment notebook and code artifacts for future reference.\n",
+        "- Document any changes to features, model parameters, or validation strategy.\n",
+        "- Maintain a log of leaderboard scores and notes on each submission.\n",
+        "- Ensure all steps are reproducible from raw data to submission.\n",
+        "\n",
+        "**Professional Takeaway:**\n",
+        "This deployment workflow ensures robust, transparent, and reproducible submission for the Titanic Kaggle competition, aligning with CRISP-DM and business requirements.\n"
+      ]
     }
-   ],
-   "source": [
-    "# Validate submission file format\n",
-    "try:\n",
-    "    submission\n",
-    "except NameError:\n",
-    "    print('ERROR: Submission file not created. Please run the previous cell and ensure required files are present.')\n",
-    "else:\n",
-    "    assert submission.shape == (418, 2), 'Submission must have 418 rows and 2 columns.'\n",
-    "    assert set(submission.columns) == {'PassengerId', 'Survived'}, 'Columns must be PassengerId and Survived.'\n",
-    "    assert submission['Survived'].isin([0,1]).all(), 'Survived must be 0 or 1.'\n",
-    "    print('Submission file format validated.')\n",
-    "\n",
-    "    # Log leaderboard score (manual step after Kaggle submission)\n",
-    "    lb_score = None  # Fill in after submission\n",
-    "    print(f'Kaggle LB score: {lb_score if lb_score else \"<to be filled after submission>\"}')"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "base",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.7"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "b338eb18",
-   "metadata": {},
-   "source": [
-    "## 2. Archiving & Reproducibility\n",
-    "\n",
-    "- Archive the final model pipeline, feature columns, and submission file.\n",
-    "- Save the deployment notebook and code artifacts for future reference.\n",
-    "- Document any changes to features, model parameters, or validation strategy.\n",
-    "- Maintain a log of leaderboard scores and notes on each submission.\n",
-    "- Ensure all steps are reproducible from raw data to submission.\n",
-    "\n",
-    "**Professional Takeaway:**\n",
-    "This deployment workflow ensures robust, transparent, and reproducible submission for the Titanic Kaggle competition, aligning with CRISP-DM and business requirements."
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "base",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- Document deployment steps with explicit use of saved preprocessor and final model
- Load preprocessor alongside model to generate predictions and produce submission file
- Clarify archiving instructions for model, preprocessor, and submission artifacts

## Testing
- `pip install -q pandas joblib scikit-learn nbformat nbconvert` *(failed: Could not find a version that satisfies the requirement pandas)*
- `jupyter nbconvert --to notebook --execute notebooks/06_deployment_submission.ipynb --output /tmp/06_deployment_submission_executed.ipynb` *(failed: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a24841614c8326a3a168c49a80b47f